### PR TITLE
fix: autodiscover on relogin

### DIFF
--- a/src/screens/login/AutoDiscover.ts
+++ b/src/screens/login/AutoDiscover.ts
@@ -1,8 +1,6 @@
-import Zeroconf, { Service } from 'react-native-zeroconf';
+import type { Service } from 'react-native-zeroconf';
 import axios from 'axios';
 import cheerio from 'cheerio';
-
-const zeroconf = new Zeroconf();
 
 export type ValidValidatedInstance = {
   isValid: true;
@@ -44,19 +42,4 @@ export async function validateInstance(service: Service): Promise<ValidatedInsta
       isValid: false,
     };
   }
-}
-
-export function beginAutoDiscover(onResolved: (service: ValidValidatedInstance) => void) {
-  zeroconf.scan('ssh', 'tcp');
-  zeroconf.on('resolved', async service => {
-    const validatedInstance = await validateInstance(service);
-    if (validatedInstance.isValid) {
-      onResolved(validatedInstance);
-    }
-  });
-}
-
-export function stopDiscovering() {
-  zeroconf.stop();
-  zeroconf.removeDeviceListeners();
 }


### PR DESCRIPTION
Due to a the broken `useEffect` return autodiscovery was not properly cleaned up and therefore did not work after you've logged in and then logged out without restarting the app.